### PR TITLE
[Firefly] Codification: aws_cloudwatch_log_group

### DIFF
--- a/infl-6375c2af5ccf43b943f95996.tf
+++ b/infl-6375c2af5ccf43b943f95996.tf
@@ -1,0 +1,18 @@
+resource "aws_cloudwatch_log_group" "awslambdahelm-provider-vpc-connector-0a3f07aabe6dda20455a1cd03161066a-05f" {
+  name = "/aws/lambda/helm-provider-vpc-connector-0a3f07aabe6dda20455a1cd03161066a"
+}
+
+
+
+
+resource "aws_cloudwatch_log_group" "awslambdaawsqs-kubernetes-resource-proxy-TanzuCluster-83a" {
+  name = "/aws/lambda/awsqs-kubernetes-resource-proxy-TanzuCluster"
+}
+
+
+
+
+resource "aws_cloudwatch_log_group" "awseksTanzuClustercluster-a8a" {
+  name = "/aws/eks/TanzuCluster/cluster"
+}
+


### PR DESCRIPTION
## Firefly Codification

#### Firefly has created this PR to codify cloud resources.
[Review Recommended]
As this is a private repository, Firefly does not have access. Therefore, this PR has been created automatically, but appears to have been created by a real user.

#### Terraform Import
		terraform import aws_cloudwatch_log_group.awslambdahelm-provider-vpc-connector-0a3f07aabe6dda20455a1cd03161066a-05f /aws/lambda/helm-provider-vpc-connector-0a3f07aabe6dda20455a1cd03161066a
		terraform import aws_cloudwatch_log_group.awslambdaawsqs-kubernetes-resource-proxy-TanzuCluster-83a /aws/lambda/awsqs-kubernetes-resource-proxy-TanzuCluster
		terraform import aws_cloudwatch_log_group.awseksTanzuClustercluster-a8a /aws/eks/TanzuCluster/cluster
